### PR TITLE
FSM 에디터

### DIFF
--- a/Assets/Scripts/Core/FSM/Editor.meta
+++ b/Assets/Scripts/Core/FSM/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c23a138bce1e304b83becca61404bc4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/FSM/Editor/FSMPlayerEditor.cs
+++ b/Assets/Scripts/Core/FSM/Editor/FSMPlayerEditor.cs
@@ -20,14 +20,23 @@ namespace HaewolWorkshop
         private Type targetType = null;
 
         private int statePopupIndex = 0;
+        private string currentStateName = "";
 
-        private void Awake()
+
+        protected void OnEnable()
         {
+            SceneView.duringSceneGui += this.OnSceneGUI;
+
             targetType = target.GetType();
             while (targetType.BaseType != typeof(MonoBehaviour))
             {
                 targetType = targetType.BaseType;
             }
+        }
+
+        protected void OnDisable()
+        {
+            SceneView.duringSceneGui -= this.OnSceneGUI;
         }
 
         public override void OnInspectorGUI()
@@ -39,6 +48,13 @@ namespace HaewolWorkshop
             base.OnInspectorGUI();
         }
 
+        private void OnSceneGUI(SceneView sceneView)
+        {
+            var transform = ((MonoBehaviour)target).transform;
+            Handles.Label(transform.position + Vector3.up, currentStateName);
+        }
+
+
         private void ShowStateInfo()
         {
             if (!Application.isPlaying)
@@ -46,7 +62,7 @@ namespace HaewolWorkshop
                 return;
             }
 
-            var currentStateName = GetTypeName(GetValue("currentState"));
+            currentStateName = GetTypeName(GetValue("currentState"));
             var previousStateName = GetTypeName(GetValue("previousState"));
             var globalStateName = GetTypeName(GetValue("globalState"));
 
@@ -55,11 +71,23 @@ namespace HaewolWorkshop
             SetStateList((dynamic)GetValue("states"), ids, names, currentStateName);
 
 
-            EditorGUILayout.LabelField($"GLOBAL : {globalStateName}");
+
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox, GUILayout.Height(55));
 
             EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.LabelField($"{previousStateName} -> ");
+            GUILayout.Label($"GLOBAL : ", EditorStyles.whiteLargeLabel, GUILayout.Width(100));
+            GUILayout.Label($"{globalStateName}", EditorStyles.largeLabel, GUILayout.ExpandWidth(false));
+            EditorGUILayout.EndHorizontal();
 
+            EditorGUILayout.BeginHorizontal();
+
+            GUILayout.Label("PreviousState : ", EditorStyles.whiteLargeLabel, GUILayout.Width(100));
+            GUILayout.Label($"{previousStateName}", EditorStyles.largeLabel, GUILayout.ExpandWidth(false));
+
+
+            GUILayout.Label("➜", EditorStyles.whiteLargeLabel, GUILayout.Width(20));
+
+            GUILayout.Label("CurrentState : ", EditorStyles.whiteLargeLabel, GUILayout.Width(100));
             int newValue = EditorGUILayout.Popup(statePopupIndex, names.ToArray());
 
             if (newValue != statePopupIndex)
@@ -69,9 +97,7 @@ namespace HaewolWorkshop
             }
 
             EditorGUILayout.EndHorizontal();
-
-
-
+            EditorGUILayout.EndVertical();
         }
 
         private object GetValue(string fieldName)
@@ -92,7 +118,6 @@ namespace HaewolWorkshop
             {
                 var name = GetTypeName(values[i]);
                 names.Add(name);
-
                 ids.Add(keys[i]);
 
                 if (name == currentStateName)

--- a/Assets/Scripts/Core/FSM/Editor/FSMPlayerEditor.cs
+++ b/Assets/Scripts/Core/FSM/Editor/FSMPlayerEditor.cs
@@ -11,12 +11,6 @@ namespace HaewolWorkshop
     [CustomEditor(typeof(FSMPlayer<>), true)]
     public class FSMPlayerEditor : Editor
     {
-        private struct State
-        {
-            public int id;
-            public string name;
-        }
-
         private Type targetType = null;
 
         private int statePopupIndex = 0;
@@ -69,7 +63,6 @@ namespace HaewolWorkshop
             var ids = new List<int>();
             var names = new List<string>();
             SetStateList((dynamic)GetValue("states"), ids, names, currentStateName);
-
 
 
             EditorGUILayout.BeginVertical(EditorStyles.helpBox, GUILayout.Height(55));

--- a/Assets/Scripts/Core/FSM/Editor/FSMPlayerEditor.cs
+++ b/Assets/Scripts/Core/FSM/Editor/FSMPlayerEditor.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using UnityEditor;
+using System.Linq;
+
+namespace HaewolWorkshop
+{
+    [CustomEditor(typeof(FSMPlayer<>), true)]
+    public class FSMPlayerEditor : Editor
+    {
+        private struct State
+        {
+            public int id;
+            public string name;
+        }
+
+        private Type targetType = null;
+
+        private int statePopupIndex = 0;
+
+        private void Awake()
+        {
+            targetType = target.GetType();
+            while (targetType.BaseType != typeof(MonoBehaviour))
+            {
+                targetType = targetType.BaseType;
+            }
+        }
+
+        public override void OnInspectorGUI()
+        {
+            ShowStateInfo();
+
+            EditorGUILayout.Space();
+
+            base.OnInspectorGUI();
+        }
+
+        private void ShowStateInfo()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            var currentStateName = GetTypeName(GetValue("currentState"));
+            var previousStateName = GetTypeName(GetValue("previousState"));
+            var globalStateName = GetTypeName(GetValue("globalState"));
+
+            var ids = new List<int>();
+            var names = new List<string>();
+            SetStateList((dynamic)GetValue("states"), ids, names, currentStateName);
+
+
+            EditorGUILayout.LabelField($"GLOBAL : {globalStateName}");
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField($"{previousStateName} -> ");
+
+            int newValue = EditorGUILayout.Popup(statePopupIndex, names.ToArray());
+
+            if (newValue != statePopupIndex)
+            {
+                statePopupIndex = newValue;
+                targetType.GetMethod("ChangeState").Invoke(target, new object[1] { ids[statePopupIndex] });
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+
+
+        }
+
+        private object GetValue(string fieldName)
+        {
+            return targetType.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Default)?.GetValue(target);
+        }
+
+        private string GetTypeName(object type)
+        {
+            return type?.ToString()?.Split('.')[^1] ?? "None";
+        }
+
+        private void SetStateList<T>(Dictionary<int, T> states, List<int> ids, List<string> names, string currentStateName)
+        {
+            var keys = states.Keys.ToList();
+            var values = states.Values.ToList();
+            for (int i = 0; i < states.Count; i++)
+            {
+                var name = GetTypeName(values[i]);
+                names.Add(name);
+
+                ids.Add(keys[i]);
+
+                if (name == currentStateName)
+                {
+                    statePopupIndex = i;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/FSM/Editor/FSMPlayerEditor.cs.meta
+++ b/Assets/Scripts/Core/FSM/Editor/FSMPlayerEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfda3f952bb0acc4abbdc7e55836a9e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## FSM 에디터

### 현재 상태 보기 및 수동 변경

![image](https://user-images.githubusercontent.com/96484044/225109835-ab008209-d973-4ca6-b66a-09377d5c676f.png)

현재 FSMPlayer의 globalState, previousState, currentState 를 확인하고
currentState 를 수동으로 변경할 수 있음

#### FSMPlayer 타입 가져오기

`FSMPlayer`는 제네릭 클래스이기 때문에 `target`의 FSMPlayer가 정확히 어떤 값인지 가져오기 어려웠음
`target` 타입의 `BaseType`를 `MonoBehavior`이 나올때 까지 타고 타고 올라가 `FSMPlayer` 타입을 구해낼 수 있었음


#### 현재 상태 가져오기

`FSMPlayer`에서 state 정보는 private 처리되어 있기 때문에
리플렉션을 사용해 타입만을 가져와 타입명을 표시하였음

#### 모든 상태 가져오기

모든 state 정보를 담고 있는`states` 딕셔너리의 Value는 제네릭 인자를 사용하기 때문에
딕셔너리의 값들을 제대로 가져올 수 없던 문제가 있었음

딕셔너리의 정보를 읽는 제네릭 함수를 만들고
`states` 오브젝트를 dynamic으로 넘겨줘 `T`의 타입을 가져올 수 있었음

딕셔너리의 Key값은 `ChangeState()`를 호출하는 용도로 사용

https://stackoverflow.com/a/13608657

### 레이블

![image](https://user-images.githubusercontent.com/96484044/225111987-0510ed4e-d45a-49b7-8423-324b15315bc9.png)

현재 `FSMPlayer` 를 사용하는 모든 엔티티의 상태를 표시함

`target`의 포지션 기준 y 좌표 1 위에 표시
(보통 엔티티의 좌표가 바닥 기준이기 때문에 약간 위로 올림)