### PR TITLE
엑셀 컨버터 관련 수정

### DIFF
--- a/Assets/Scripts/Core/GameData/Editor/ExcelConverter.cs
+++ b/Assets/Scripts/Core/GameData/Editor/ExcelConverter.cs
@@ -30,7 +30,7 @@ namespace HaewolWorkshop
                 string[] files = Directory.GetFiles(GameDataPath, $"*.xlsx");
                 foreach (string file in files)
                 {
-                    var filename = file.Split('\\', '.');
+                    var filename = file.Split('\\', '.', '/');
                     var name = filename[^2];
 
                     stopWatch.Start();

--- a/Assets/Scripts/Core/GameData/Editor/ExcelConverter.cs
+++ b/Assets/Scripts/Core/GameData/Editor/ExcelConverter.cs
@@ -111,7 +111,7 @@ namespace HaewolWorkshop
 
                 // 나머지 행들을 돌아가며 데이터 가공
 
-                for (int rowNum = 1; rowNum < sheet.LastRowNum; rowNum++)
+                for (int rowNum = 1; rowNum <= sheet.LastRowNum; rowNum++)
                 {
                     var datas = new Dictionary<string, string>();
                     IRow row = sheet.GetRow(rowNum);

--- a/Assets/Scripts/Core/GameData/Editor/ExcelConverter.cs
+++ b/Assets/Scripts/Core/GameData/Editor/ExcelConverter.cs
@@ -33,6 +33,11 @@ namespace HaewolWorkshop
                     var filename = file.Split('\\', '.', '/');
                     var name = filename[^2];
 
+                    if(name.StartsWith("~$"))
+                    {
+                        continue;
+                    }
+
                     stopWatch.Start();
                     Debug.Log($"Converting {name}...");
 
@@ -74,7 +79,7 @@ namespace HaewolWorkshop
 
             var columns = new List<string>();
 
-            using (var stream = new FileStream(excelFilePath, FileMode.Open))
+            using (var stream = new FileStream(excelFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var xssWorkbook = new XSSFWorkbook(stream);
                 ISheet sheet = xssWorkbook.GetSheetAt(0);

--- a/Assets/Scripts/Editor/Builder.cs
+++ b/Assets/Scripts/Editor/Builder.cs
@@ -15,6 +15,8 @@ namespace HaewolWorkshop
         [MenuItem("Build/빌드하기")]
         public static void Build()
         {
+            ExcelConverter.ConvertExcelToJson();
+            
             var stream = new FileStream(BuildSettingPath, FileMode.Open);
             var reader = new StreamReader(stream);
 


### PR DESCRIPTION
## mac에서의 문제

### 파일 이름을 구할 때의 문제

mac에서는 파일 경로 구분을 `\` 가 아닌 `/` 로 하기 때문에  
의도대로 Split할 수 없었음

### LastRowNum

정확한 이유는 알 수 없으나  
윈도우에서는 `LastRowNum - 1` 까지 읽어도 끝까지 읽을 수 있었지만  
맥에서 만든 엑셀 시트에서는 `LastRowNum` 까지 모두 읽어야 마지막 Row에 접근할 수 있었음

`GetRow`는 out of range 오류를 발생시키지 않기 때문에  
모든 경우에서 `LastRowNum` 까지 모두 읽도록 수정

<br>

## 기타

- 이미 열려있는 엑셀 파일을 컨버팅할 수 없던 오류 수정
    - `FileShare.ReadWrite` 설정
    - 오피스 임시 파일 (`~$`로 시작하는 파일) 제외
- 빌드 프로세스에 `ConvertExcelToJson()` 추가